### PR TITLE
Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.1.0 (12/20/2022)
+
+### API changes
+- `LitDDPM` takes samplers as arguments instead of creating them internally.
+- `DDPMSampler`sets beta values (i.e. noise schedule) internally.
+
+### Features
+- Add EMA callback
+- Documentation for code and a summary of DDPM
+
 ## v0.0.2 (12/16/2022)
 
 ### Fix

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Diffusion Models Made Easy(`dmme`) is a collection of easy to understand diffusi
 
 # Getting Started
 
+Documentation is available at https://diffusion-models-made-easy.readthedocs.io/en/latest/
+
 ## Installation
 
 Install from pip

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,7 +11,7 @@ import sphinxcontrib.katex as katex
 project = "dmme"
 copyright = "2022, Chanhyuk Jung"
 author = "Chanhyuk Jung"
-release = "0.0.2"
+release = "0.1.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dmme"
-version = "0.0.2"
+version = "0.1.0"
 authors = [
     { name="Chanhyuk Jung", email="urw7rs@stu.kmu.ac.kr" },
 ]

--- a/src/dmme/__init__.py
+++ b/src/dmme/__init__.py
@@ -2,6 +2,6 @@ from .ddpm import LitDDPM, DDPMSampler
 
 from .data_modules import CIFAR10
 
-__version__ = "0.0.2"
+__version__ = "0.1.0"
 
 __all__ = ["LitDDPM", "DDPMSampler", "CIFAR10"]


### PR DESCRIPTION
## v0.1.0 (12/20/2022)

### API changes
- `LitDDPM` takes samplers as arguments instead of creating them internally.
- `DDPMSampler`sets beta values (i.e. noise schedule) internally.

### Features
- Add EMA callback
- Documentation for code and a summary of DDPM