### PR TITLE
remove image generation step and cleanup sampler api

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,13 @@ from pytorch_lightning.loggers import WandbLogger
 from dmme import LitDDPM, DDPMSampler, CIFAR10
 from dmme.ddpm import UNet
 
+from dmme.callbacks import GenerateImage
+
 
 def main():
     trainer = Trainer(
         logger=WandbLogger(project="CIFAR10 Image Generation", name="DDPM"),
+        callbacks=GenerateImage((3, 32, 32)),
         gradient_clip_val=1.0,
         auto_select_gpus=True,
         accelerator="gpu",
@@ -94,15 +97,14 @@ from dmme import CIFAR10
 
 from dmme.ddpm import UNet, DDPMSampler
 from dmme.lr_scheduler import WarmupLR
-from dmme.noise_schedules import linear_schedule
 
 
 def train(timesteps=1000, lr=2e-4, clip_val=1.0, warmup=5000, max_steps=800_000):
     device = torch.device("cuda") if torch.cuda.is_available() else "cpu"
 
     model = UNet()
-    beta = linear_schedule(timesteps=timesteps)
-    sampler = DDPMSampler(model, timesteps=timesteps, beta=beta)
+
+    sampler = DDPMSampler(model, timesteps=timesteps)
     sampler = sampler.to(device)
 
     cifar10 = CIFAR10()
@@ -125,7 +127,7 @@ def train(timesteps=1000, lr=2e-4, clip_val=1.0, warmup=5000, max_steps=800_000)
             optimizer.zero_grad()
             loss.backward()
 
-            torch.nn.utils.clip_grad_norm(sampler.parameters(), clip_val)
+            torch.nn.utils.clip_grad_norm_(sampler.parameters(), clip_val)
 
             optimizer.step()
             lr_scheduler.step()
@@ -140,6 +142,7 @@ def train(timesteps=1000, lr=2e-4, clip_val=1.0, warmup=5000, max_steps=800_000)
 
 if __name__ == "__main__":
     train()
+
 ```
 
 ## Supported Diffusion Models

--- a/configs/ddpm/cifar10.yaml
+++ b/configs/ddpm/cifar10.yaml
@@ -12,6 +12,12 @@ trainer:
       init_args:
         save_last: true
     - class_path: pytorch_lightning.callbacks.LearningRateMonitor
+    - class_path: dmme.callbacks.GenerateImage
+      init_args:
+        imgsize:
+          - 3
+          - 32
+          - 32
   default_root_dir: null
   gradient_clip_val: 1.0
   gradient_clip_algorithm: null

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,6 +7,7 @@ SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build
+PKGDIR        = ../src
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -21,3 +22,6 @@ help:
 
 server: html
 	python3 -m http.server -d "$(BUILDDIR)/html"
+
+dev:
+	sphinx-autobuild "$(SOURCEDIR)" "$(BUILDDIR)" --watch ${PKGDIR}

--- a/docs/source/callbacks.md
+++ b/docs/source/callbacks.md
@@ -1,8 +1,19 @@
-# EMA Callback
+# Callbacks
 
 ```{eval-rst}
 .. currentmodule:: dmme.callbacks
 
-.. autoclass:: EMA
-    :members:
+.. autosummary::
+    :nosignatures:
+
+    EMA
+    GenerateImage
+```
+
+```{toctree}
+:caption: 'Callbacks:'
+:maxdepth: 2
+
+callbacks/ema
+callbacks/generate
 ```

--- a/docs/source/callbacks/ema.md
+++ b/docs/source/callbacks/ema.md
@@ -1,0 +1,8 @@
+# EMA
+
+```{eval-rst}
+.. currentmodule:: dmme.callbacks
+
+.. autoclass:: EMA
+    :members:
+```

--- a/docs/source/callbacks/generate.md
+++ b/docs/source/callbacks/generate.md
@@ -1,0 +1,8 @@
+# GenerateImage
+
+```{eval-rst}
+.. currentmodule:: dmme.callbacks
+
+.. autoclass:: GenerateImage
+    :members:
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "torch",
     "torchvision",
     "einops",
-    "pytorch-lightning",
+    "pytorch-lightning>=1.8",
     "jsonargparse[signatures]>=4.12.0",
     "torchmetrics[image]",
     "wandb",

--- a/scripts/lit_main.py
+++ b/scripts/lit_main.py
@@ -5,10 +5,13 @@ from pytorch_lightning.loggers import WandbLogger
 from dmme import LitDDPM, DDPMSampler, CIFAR10
 from dmme.ddpm import UNet
 
+from dmme.callbacks import GenerateImage
+
 
 def main():
     trainer = Trainer(
         logger=WandbLogger(project="CIFAR10 Image Generation", name="DDPM"),
+        callbacks=GenerateImage((3, 32, 32)),
         gradient_clip_val=1.0,
         auto_select_gpus=True,
         accelerator="gpu",

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -7,15 +7,14 @@ from dmme import CIFAR10
 
 from dmme.ddpm import UNet, DDPMSampler
 from dmme.lr_scheduler import WarmupLR
-from dmme.noise_schedules import linear_schedule
 
 
 def train(timesteps=1000, lr=2e-4, clip_val=1.0, warmup=5000, max_steps=800_000):
     device = torch.device("cuda") if torch.cuda.is_available() else "cpu"
 
     model = UNet()
-    beta = linear_schedule(timesteps=timesteps)
-    sampler = DDPMSampler(model, timesteps=timesteps, beta=beta)
+
+    sampler = DDPMSampler(model, timesteps=timesteps)
     sampler = sampler.to(device)
 
     cifar10 = CIFAR10()
@@ -38,7 +37,7 @@ def train(timesteps=1000, lr=2e-4, clip_val=1.0, warmup=5000, max_steps=800_000)
             optimizer.zero_grad()
             loss.backward()
 
-            torch.nn.utils.clip_grad_norm(sampler.parameters(), clip_val)
+            torch.nn.utils.clip_grad_norm_(sampler.parameters(), clip_val)
 
             optimizer.step()
             lr_scheduler.step()

--- a/src/dmme/callbacks/__init__.py
+++ b/src/dmme/callbacks/__init__.py
@@ -1,1 +1,2 @@
 from .ema import EMA
+from .generate import GenerateImage

--- a/src/dmme/callbacks/generate.py
+++ b/src/dmme/callbacks/generate.py
@@ -1,0 +1,87 @@
+import pytorch_lightning as pl
+
+from dmme.common import make_history, gaussian, denorm
+
+
+class GenerateImage(pl.Callback):
+    r"""Generate samples to check training progress
+
+    Args:
+        imgsize (Tuple[int, int, int]): A tuple of ints representing image shape :math:`(C, H, W)`
+        batch_size (int): Number of samples to generate
+        vis_length (int): Length of denoising sequence to visualize
+        every_n_epochs (int): Only save those images every N epochs
+        test (bool): generates images on test if set to true
+    """
+
+    def __init__(
+        self, imgsize, batch_size=8, vis_length=20, every_n_epochs=5, test=False
+    ):
+        super().__init__()
+
+        self.imgsize = imgsize
+        self.batch_size = batch_size
+        self.vis_length = vis_length
+        self.every_n_epochs = every_n_epochs
+
+        self.test = test
+
+    def on_train_epoch_end(self, trainer, pl_module):
+        self._shared_hook(trainer, pl_module)
+
+    def on_test_epoch_end(self, trainer, pl_module):
+        if self.test:
+            self._shared_hook(trainer, pl_module)
+
+    def _shared_hook(self, trainer, pl_module):
+        if trainer.current_epoch % self.every_n_epochs == 0:
+
+            if trainer.logger is None:
+                return
+
+            history = self.generate_img(pl_module)
+            grid = make_history(history)
+
+            if isinstance(trainer.logger, list):
+                for logger in trainer.logger:
+                    self._log(logger, grid)
+            else:
+                self._log(trainer.logger, grid)
+
+    def _log(self, logger, grid):
+        experiment = logger.experiment
+
+        if isinstance(logger, pl.loggers.WandbLogger):
+            logger.log_image("generated_images", [grid])
+
+        if isinstance(logger, pl.loggers.TensorBoardLogger):
+            experiment.add_image("generated_images", grid, pl_module.global_step)
+
+    def generate_img(self, pl_module):
+        pl_module.eval()
+
+        denoising_sequence = []
+
+        x_t = gaussian((self.batch_size, *self.imgsize), device=pl_module.device)
+        denoising_sequence.append(denorm(x_t))
+
+        timesteps = pl_module.hparams.timesteps
+
+        step = timesteps // (self.vis_length - 1)
+        if timesteps % (self.vis_length - 1) > 0:
+            step += 1
+
+        t = timesteps
+        save_t = t - step
+        while t > 0:
+            while t > save_t:
+                x_t = pl_module(x_t, t, t - 1)
+                t -= 1
+
+            denoising_sequence.append(denorm(x_t.clone().detach()))
+
+            save_t -= step
+
+        pl_module.train()
+
+        return denoising_sequence

--- a/src/dmme/ddpm/ddpm_sampler.py
+++ b/src/dmme/ddpm/ddpm_sampler.py
@@ -4,7 +4,7 @@ import torch.nn.functional as F
 
 import einops
 
-from dmme.common import gaussian, gaussian_like, uniform_int
+from dmme.common import gaussian_like, uniform_int
 
 
 class DDPMSampler(nn.Module):

--- a/src/dmme/ddpm/ddpm_sampler.py
+++ b/src/dmme/ddpm/ddpm_sampler.py
@@ -4,7 +4,7 @@ import torch.nn.functional as F
 
 import einops
 
-from dmme.common import gaussian, gaussian_like, uniform_int, denorm
+from dmme.common import gaussian, gaussian_like, uniform_int
 
 
 class DDPMSampler(nn.Module):
@@ -35,6 +35,20 @@ class DDPMSampler(nn.Module):
 
         if beta is not None:
             self.register_alphas(beta)
+
+    def forward(self, x_t, t):
+        r"""Predicts the noise given :math:`x_t` and :math:`t`
+
+        Applies forward to the internal model
+
+        Expects :math:`x_t` to have shape :math:`(N, C, H, W)`
+
+        Args:
+            x_t (torch.Tensor): image
+            t (int): :math:`t` in :math:`\bold{x}_t`
+        """
+
+        return self.model(x_t, t)
 
     def forward_process(self, x_0, t, noise=None):
         r"""Forward Diffusion Process
@@ -189,80 +203,25 @@ class DDPMSampler(nn.Module):
         return loss
 
     @torch.inference_mode()
-    def sample(self, x_shape, start=0, end=None, step=1, save_last=True, device=None):
+    def sample(self, x_t, t, noise=None):
         r"""Generate Samples
 
-        Iteratively sample from :math:`p_\theta(x_t,t)`
-
-        .. code-block:: python
-
-            x = gaussian()
-            for t in range(T, 0, -1):
-                z = gaussian() if t > 1 else 0
-                x = reverse_process(x, t, z)
-            return x
-
-        start, end, step parameters specify which steps to return
+        Iteratively sample from :math:`p_\theta(x_{t-1}|x_t)` starting from :math:`x_T`
 
         Args:
-            x_shape (Tuple[int, int, int]): image shape
-            start (int): start t
-            end (int): end t
-            step (int): step
-            save_last (bool): whether to save last sample
-            device (torch.device): device
+            x_t (Tuple[int, int, int]): image shape
+            t (int): timestep :math:`t` to sample from
 
         Returns:
-            (List[torch.Tensor]): denoised samples
+            (torch.Tensor): sample from :math:`p_\theta(x_{t-1}|x_t)` starting from :math:`x_T`
         """
 
-        history = []
+        if t == 1:
+            x_t = self.reverse_process(x_t, 1, noise=0)
+        else:
+            x_t = self.reverse_process(x_t, t, noise)
 
-        def save(x):
-            history.append(denorm(x))
-
-        def format(n):
-            if n < 0:
-                n %= self.timesteps
-                n += 1
-            elif n is None:
-                n = self.timesteps + 1
-            return n
-
-        start = format(start)
-        end = format(end)
-
-        x_t = gaussian(x_shape, device=device)
-
-        if self.timesteps == start:
-            save(x_t)
-
-        for t in range(self.timesteps, 1, -1):
-            x_t = self.reverse_process(x_t, t)
-
-            if end > t - 1 >= start:
-                if (t - 1 - start) % step == 0:
-                    save(x_t)
-
-        x_0 = self.reverse_process(x_t, 1, noise=0)
-        if save_last or end > 0 >= start:
-            save(x_0)
-
-        return history
-
-    def forward(self, x, t):
-        r"""Predicts the noise given :math:`x_t` and :math:`t`
-
-        Applies forward to the internal model
-
-        Expects :math:`x_t` to have shape :math:`(N, C, H, W)`
-
-        Args:
-            x (torch.Tensor): image
-            t (int): :math:`t` in :math:`\bold{x}_t`
-        """
-
-        return self.model(x, t)
+        return x_t
 
 
 def linear_schedule(timesteps, start=0.0001, end=0.02):

--- a/src/dmme/ddpm/lit_ddpm.py
+++ b/src/dmme/ddpm/lit_ddpm.py
@@ -1,19 +1,21 @@
 from typing import Tuple
 
+import math
+
 import torch
-from torch import nn
 from torch.optim import Adam
 
 import pytorch_lightning as pl
 
+from dmme.ddpm.ddpm_sampler import DDPMSampler
+
 from torchmetrics.image.fid import FrechetInceptionDistance
 from torchmetrics.image.inception import InceptionScore
 
-from dmme.common import denorm, make_history
+from dmme.common import denorm, make_history, gaussian_like
 from dmme.lr_scheduler import WarmupLR
 
 from dmme.callbacks import EMA
-from pytorch_lightning.callbacks import LearningRateMonitor, ModelCheckpoint
 
 
 class LitDDPM(pl.LightningModule):
@@ -32,7 +34,7 @@ class LitDDPM(pl.LightningModule):
 
     def __init__(
         self,
-        sampler: nn.Module,
+        sampler: DDPMSampler,
         lr: float = 2e-4,
         warmup: int = 5000,
         imgsize: Tuple[int, int, int] = (3, 32, 32),
@@ -44,6 +46,32 @@ class LitDDPM(pl.LightningModule):
 
         self.sampler = sampler
 
+    def forward(self, x_t, start_t, stop_t=0, step_t=-1, noise=None):
+        r"""Iteratively sample from :math:`p_\theta(x_{t-1}|x_t)` starting with :math:`x_t` with start, stop step specified from arguments
+
+        Args:
+            x_t (torch.Tensor): image of shape :math:`(N, C, H, W)`
+            start_t (int): starting :math:`t` to sample from
+            stop_t (int): stops sampling when reached
+            steps_t (int): step sizes for sequence
+            noise (torch.Tensor): noise to use for sampling, if `None` samples new noise
+
+        Returns:
+            (torch.Tensor): generated samples
+        """
+
+        if start_t is None:
+            start_t = self.sampler.timesteps
+
+        if noise is None:
+            num_steps = abs(stop_t - start_t) // abs(step_t) + 1
+            noise = [None] * num_steps
+
+        for t in range(start_t, stop_t, step_t):
+            x_t = self.sampler.sample(x_t, t, noise[t])
+
+        return x_t
+
     def training_step(self, batch, batch_idx):
         """Compute loss using sampler"""
         x_0, _ = batch
@@ -52,26 +80,23 @@ class LitDDPM(pl.LightningModule):
         self.log("train/loss", loss)
         return loss
 
-    def training_epoch_end(self, outputs):
-        """Generate samples at the end of the epoch"""
-        self.sample_and_log(num_samples=16, length=16)
-
     def test_step(self, batch, batch_idx):
         """Generate samples for evaluation"""
         x, _ = batch
-        x = denorm(x)
 
-        self.fid.update(x, real=True)
+        self.fid.update(denorm(x), real=True)
 
-        batch_size = x.size(0)
-        history = self.sample_and_log(num_samples=batch_size, length=1)
+        x_T = gaussian_like(x)
+        x_0 = self(x_T)
 
-        final_img = history[-1]
-        self.fid.update(final_img, real=False)
-        self.inception.update(final_img)
+        fake_x = denorm(x_0)
+
+        self.fid.update(fake_x, real=False)
+        self.inception.update(fake_x)
 
     def test_epoch_end(self, outputs):
         """Compute metrics and log at the end of the epoch"""
+
         fid_score = self.fid.compute()
         kl_mean, _ = self.inception.compute()
         inception_score = torch.exp(kl_mean)
@@ -105,33 +130,3 @@ class LitDDPM(pl.LightningModule):
         ema_callback = EMA(decay=self.hparams.decay)
 
         return ema_callback
-
-    def sample_and_log(self, num_samples=1, length=1):
-        """Sample data and log to logger
-
-        Args:
-            num_samples (int): number of samples
-            length (int): length of history to save in :math:`T` timesteps
-        """
-        if length == 1:
-            start = end = 0
-            step = 1
-        elif length > 2:
-            start = 0
-            end = self.sampler.timesteps + 1
-            step = (self.sampler.timesteps - 1) // (length - 1)
-
-        history = self.sampler.sample(
-            (num_samples, *self.hparams.imgsize),
-            start,
-            end,
-            step,
-            save_last=True,
-            device=self.device,
-        )
-
-        grid = make_history(history)
-
-        self.logger.log_image("samples", [grid])
-
-        return history

--- a/src/dmme/ddpm/lit_ddpm.py
+++ b/src/dmme/ddpm/lit_ddpm.py
@@ -1,7 +1,5 @@
 from typing import Tuple
 
-import math
-
 import torch
 from torch.optim import Adam
 
@@ -12,7 +10,7 @@ from dmme.ddpm.ddpm_sampler import DDPMSampler
 from torchmetrics.image.fid import FrechetInceptionDistance
 from torchmetrics.image.inception import InceptionScore
 
-from dmme.common import denorm, make_history, gaussian_like
+from dmme.common import denorm, gaussian_like
 from dmme.lr_scheduler import WarmupLR
 
 from dmme.callbacks import EMA
@@ -65,10 +63,10 @@ class LitDDPM(pl.LightningModule):
 
         if noise is None:
             num_steps = abs(stop_t - start_t) // abs(step_t) + 1
-            noise = [None] * num_steps
+            noise = [None] * self.sampler.timesteps
 
         for t in range(start_t, stop_t, step_t):
-            x_t = self.sampler.sample(x_t, t, noise[t])
+            x_t = self.sampler.sample(x_t, t, noise[t - 1])
 
         return x_t
 


### PR DESCRIPTION
`LitDDPM` uses wandb in image generation step so when `WandbLogger` is not used, generation step causes errors. Factor out generation step into it's own `ImageGenerationCallback` and cleanup sampler api for easier image generation.